### PR TITLE
Bug Fix: PDO Error on project pages related to stock listing.

### DIFF
--- a/kp_nodes.module
+++ b/kp_nodes.module
@@ -451,21 +451,21 @@ function kp_project_germplasm_list($project = null) {
         $cvterm_id_origin = tripal_get_cvterm(array('name' => 'country_of_origin'));
 
         $sql = "SELECT
-          t1.name,
-          t1.uniquename,
-          INITCAP(genus) || ' ' || LOWER(species) AS species,
-          t2.name AS type,
-          STRING_AGG(CASE WHEN t3.type_id = :origin THEN t3.value END, '') AS origin
+          s.name,
+          s.uniquename,
+          INITCAP(o.genus) || ' ' || LOWER(o.species) AS species,
+          cvt.name AS type,
+          STRING_AGG(CASE WHEN sprop.type_id = :origin THEN sprop.value END, '') AS origin
         FROM
-          {stock} AS t1
-          LEFT JOIN {project_stock} USING(stock_id)
-          LEFT JOIN {organism} USING(organism_id)
-          LEFT JOIN {cvterm} AS t2 ON t2.cvterm_id = t1.type_id
-          LEFT JOIN {stockprop} AS t3 USING(stock_id)
+          {stock} AS s
+          LEFT JOIN {project_stock} AS projs USING(stock_id)
+          LEFT JOIN {organism} AS o USING(organism_id)
+          LEFT JOIN {cvterm} AS cvt ON cvt.cvterm_id = s.type_id
+          LEFT JOIN {stockprop} AS sprop USING(stock_id)
         WHERE
-          project_id = :project_id
-        GROUP BY t1.name, t1.uniquename, genus, species, t2.name
-        ORDER BY t1.name ASC";
+          projs.project_id = :project_id
+        GROUP BY s.name, s.uniquename, o.genus, o.species, cvt.name
+        ORDER BY s.name ASC";
 
         $args = array(
           ':origin' => $cvterm_id_origin->cvterm_id,
@@ -535,32 +535,6 @@ function kp_nodes_rawpheno_AGILE_stock_name_alter(&$stock_name, &$project_name) 
     }
   }
 }
-
-
-/**
- * Implements hook_alter().
- * Add support email to rawphenotypes block, upload page and other pages.
- *
- * @param $support_email
- *   A string, referenced variable alterable by this hook.
- *
- * @see
- *   modules/rawpheno/include/rawpheno.funciton.measurements.inc.
- */
-function kp_nodes_rawpheno_support_email_alter(&$support_email) {
-  // Referenced parameters in function: rawpheno_function_get_support_email() in @see.
-
-  // Use $support_email = 'command#value' to provide support email.
-  // username, emailadd, useridno are the supported commands.
-  // Examples:
-
-  // $support_email = 'username#Drupal user name';
-  // $support_email = 'emailadd#your@emailaddress.com';
-  // $support_email = 'userdino#Integer, Id number';
-
-  $support_email = 'username#UofS Reynold Tan';
-}
-
 
 /**
  * Implements hook_alter().

--- a/theme/template.php
+++ b/theme/template.php
@@ -160,18 +160,18 @@ function kp_nodes_preprocess_tripal_project_base(&$variables) {
 
      // Table exists.
      $sql = sprintf("SELECT
-               t1.name, t1.uniquename,
-               INITCAP(genus) || ' ' || LOWER(species) AS species,
-               t2.name AS type,
+               s.name, s.uniquename,
+               INITCAP(o.genus) || ' ' || LOWER(o.species) AS species,
+               cvt.name AS type,
                'node/' || link.nid AS node_link
              FROM
-               {stock} AS t1
+               {stock} AS s
                LEFT JOIN chado_stock AS link USING(stock_id)
-               LEFT JOIN {project_stock} USING(stock_id)
-               LEFT JOIN {organism} USING(organism_id)
-               LEFT JOIN {cvterm} AS t2 ON cvterm_id = type_id
-             WHERE project_id = :project_id
-             ORDER BY t1.name %s", $sort);
+               LEFT JOIN {project_stock} AS projs USING(stock_id)
+               LEFT JOIN {organism} AS o USING(organism_id)
+               LEFT JOIN {cvterm} AS cvt ON cvt.cvterm_id = s.type_id
+             WHERE projs.project_id = :project_id
+             ORDER BY s.name %s", $sort);
 
      $args = array(':project_id' => $project_id);
      $g = chado_query($sql, $args);
@@ -253,22 +253,22 @@ function kp_nodes_preprocess_kp_nodes_project_stocks_AGILE(&$variables) {
 
      // Table exists.
      $sql = sprintf("SELECT
-               t1.name, t1.uniquename,
-               INITCAP(genus) || ' ' || LOWER(species) AS species,
-               t2.name AS type,
+               s.name, s.uniquename,
+               INITCAP(o.genus) || ' ' || LOWER(o.species) AS species,
+               cvt.name AS type,
                'node/' || link.nid AS node_link,
-               STRING_AGG(CASE WHEN t3.type_id = %d THEN t3.value END, '') AS origin
+               STRING_AGG(CASE WHEN sprop.type_id = %d THEN sprop.value END, '') AS origin
              FROM
-               {stock} AS t1
+               {stock} AS s
                LEFT JOIN chado_stock AS link USING(stock_id)
-               LEFT JOIN {project_stock} USING(stock_id)
-               LEFT JOIN {organism} USING(organism_id)
-               LEFT JOIN {cvterm} AS t2 ON t2.cvterm_id = t1.type_id
-               LEFT JOIN {stockprop} AS t3 USING(stock_id)
+               LEFT JOIN {project_stock} AS projs USING(stock_id)
+               LEFT JOIN {organism} AS o USING(organism_id)
+               LEFT JOIN {cvterm} AS cvt ON cvt.cvterm_id = s.type_id
+               LEFT JOIN {stockprop} AS sprop USING(stock_id)
              WHERE
-               project_id = :project_id
-             GROUP BY t1.name, t1.uniquename, genus, species, t2.name, link.nid
-             ORDER BY t1.name %s", $cvterm_id_origin->cvterm_id, $sort);
+               projs.project_id = :project_id
+             GROUP BY s.name, s.uniquename, o.genus, o.species, cvt.name, link.nid
+             ORDER BY s.name %s", $cvterm_id_origin->cvterm_id, $sort);
 
      $args = array(':project_id' => $project_id);
      $g = chado_query($sql, $args);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue: n/a

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [x] This PR is dependent upon nothing

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Project pages on KnowPulse were showing an ERROR. When I checked the logs the specifics where:

> PDOException: SQLSTATE[42702]: Ambiguous column: 7 ERROR: column reference "type_id" is ambiguous LINE 1: ... LEFT JOIN chado.cvterm AS t2 ON cvterm_id = type_id ... ^: SELECT t1.name, t1.uniquename, INITCAP(genus) || ' ' || LOWER(species) AS species, t2.name AS type, 'node/' || link.nid AS node_link FROM chado.stock AS t1 LEFT JOIN chado_stock AS link USING(stock_id) LEFT JOIN chado.project_stock USING(stock_id) LEFT JOIN chado.organism USING(organism_id) LEFT JOIN chado.cvterm AS t2 ON cvterm_id = type_id WHERE project_id = :project_id ORDER BY t1.name asc; Array ( [:project_id] => 50 ) in chado_query() (line 1715 of /var/www/portal/sites/all/modules/contrib/tripal/tripal_chado/api/tripal_chado.query.api.inc).

This happened due to the completed upgrade to Chado 1.3 which caused the following query to become not specific enough:
```sql
             SELECT
               t1.name, t1.uniquename,
               INITCAP(genus) || ' ' || LOWER(species) AS species,
               t2.name AS type,
               'node/' || link.nid AS node_link
             FROM
               {stock} AS t1
               LEFT JOIN chado_stock AS link USING(stock_id)
               LEFT JOIN {project_stock} USING(stock_id)
               LEFT JOIN {organism} USING(organism_id)
               LEFT JOIN {cvterm} AS t2 ON cvterm_id = type_id
             WHERE project_id = :project_id
             ORDER BY t1.name
```

Specifically, in Chado 1.3 the organism table also has a type_id which made the column ambiguous here: `LEFT JOIN {cvterm} AS t2 ON cvterm_id = type_id`. **All queries should have every column qualified with it's table or table alias. Additionally, if you have table alias' then ensure you alias ALL tables in the query using readable names.** 

## Dependencies
<!-- If this code is dependent upon another module and/or PR, 
       state that here. -->
<!-- Include information about other modules/PRs needed for testing,
        which to enable/merge first, etc. -->
None.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [n/a] I tested on a generic Tripal Site
- [x] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing

1. Navigate to the project listing: [site]/research/projects
2. Click on AGILE -make sure it loads without error
3. Click on any non-AGILE project -make sure it loads without error