### PR TITLE
Redirect project page by using short url

### DIFF
--- a/kp_nodes.module
+++ b/kp_nodes.module
@@ -42,8 +42,35 @@ function kp_nodes_menu() {
     'type' => MENU_CALLBACK,
   );
 
+
+  // Menu option knowpulse/AGILE
+
+  // This will set a shorter and easy to remember page alias of /project/AGILE:-Application ...
+  // experiment page address and redirect to project page when KnowPulse/AGILE is used.
+  $agile_redirect = array(
+    'title' => 'Loading AGILE experiment page...',
+    'page callback' => 'kp_page_redirect',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+   );
+
+  // Case-insensitive AGILE or agile - no problem.
+  $items['AGILE'] = $agile_redirect;
+  $items['agile'] = $agile_redirect;
+
+
   return $items;
 }
+
+
+/**
+ * FUNCTION CALLBACK: Redirect to AGILE Experiment page.
+ */
+function kp_page_redirect() {
+  print 'Redirecting...';
+  drupal_goto('project/AGILE:-Application-of-Genomic-Innovation-in-the-Lentil-Economy');
+}
+
 
 /**
  * Implements hook_theme().


### PR DESCRIPTION
Issue #9 - Support short version of AGILE page url.

- This will PR will allow user to access AGILE project page using shorter and easy to remember url ie. KnowPulse/AGILE.

##METADATA
[https://github.com/uofs-pulse-binfo/kp_nodes/issues/9]

- [X] I feel this PR is ready to be merged.
- [ ] This PR is dependent upon [PR #/ nothing]

Documentation:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
Registered an item in the hook_menu for this module to recognize /AGILE and /agile urls and redirect to the experiment page.

## Dependencies
no dependencies.

## Testing?
In clone homepage, edit the homepage url  and add /AGILE or /agile and press enter key. The browser should redirect you to AGILE experiment page.

- [ ] I tested on a generic Tripal Site
- [X] I tested on a KnowPulse Clone
  in dev/A
- [ ] This PR includes automated testing